### PR TITLE
seems to be working in development if CORS-Plugin is activated

### DIFF
--- a/gosolution-app/main.js
+++ b/gosolution-app/main.js
@@ -28,7 +28,8 @@ const map = new Map({
   }),
 });
 (async () => {
-  const airports = await fetch('https://demo.ldproxy.net/zoomstack/collections/airports/items?limit=100', {
+  //const airports = await fetch('https://demo.ldproxy.net/zoomstack/collections/airports/items?limit=100', {
+  const airports = await fetch('http://localhost:8080/geoserver-2.23/ogc/features/collections/tiger:poi/items', {
     headers: {
       'Accept': 'application/geo+json'
     }


### PR DESCRIPTION
Hi GOSolutions,
just changing the URL pointing to the example data set from your local Geoserver instance should do the job. Keep in mind that you need the CORS Plugin to make it work in development environment. You can see that when monitoring the requests using the Web developer console of your browser.
Please changed the URL depending on your installation - I configured tomcat that geoserver-2.23 is available at the given URL for that I can run several geoserver instances within one tomcat each having a slightly different URL including the version number.
The limit-parameter is optional (depending on your dataset, while the f (format) parameter is notz needed in your application - it is set by the header option in line 33.

Feel free t ask any further questions and let me know which error do occur on your side. Make sure that
- the web-frontrend definitely tries to fetch data (protocoled request in browser tools)
- the OGC API service returns the data at all by trying the URL that should return GeoJSON Features in a separate browser tab

Regards
Marco Lechner